### PR TITLE
Set default hostname to 'localhost' for webpackServer

### DIFF
--- a/src/webpackServer.js
+++ b/src/webpackServer.js
@@ -79,7 +79,7 @@ export default function webpackServer(args, buildConfig, cb) {
       serverConfig.historyApiFallback = args.fallback
     }
     // The host can be overridden with --host
-    if (args.host) serverConfig.host = args.host
+    serverConfig.host = args.host || 'localhost'
     // Open a browser with --open (default browser) or --open="browser name"
     if (args.open) serverConfig.open = args.open
 


### PR DESCRIPTION
When a hostname is not provided, a user is shown a message
`The app is running at HTTP://localhost:3000/`. This, however,
is not always correct. If the development is done within the crostini
container, the default hostname will be `http://penguin.linux.test:3000/`.

Setting the default hostname to `localhost` makes everything work out of the box.
